### PR TITLE
B.Protocol support

### DIFF
--- a/contracts/ComptrollerStorage.sol
+++ b/contracts/ComptrollerStorage.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.5.16;
 
 import "./CToken.sol";
 import "./PriceOracle.sol";
+import "./IBProtocol.sol";
 
 contract UnitrollerAdminStorage {
     /**
@@ -142,4 +143,9 @@ contract ComptrollerV5Storage is ComptrollerV4Storage {
 
     /// @notice Last block at which a contributor's COMP rewards have been allocated
     mapping(address => uint) public lastContributorBlock;
+}
+
+contract ComptrollerV6Storage is ComptrollerV5Storage {
+    /// @notice CToken => IBProtocol (per CToken debt)
+    mapping(address => address) public bprotocol;
 }

--- a/contracts/IBProtocol.sol
+++ b/contracts/IBProtocol.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.5.16;
+
+interface IBProtocol {
+    function canLiquidate(
+        address cTokenBorrowed,
+        address cTokenCollateral,
+        uint repayAmount
+    )
+    external
+    view
+    returns(bool);
+}
+
+

--- a/tests/Contracts/MockBProtocol.sol
+++ b/tests/Contracts/MockBProtocol.sol
@@ -1,0 +1,21 @@
+pragma solidity ^0.5.16;
+
+contract MockBProtocol {
+    bool val;
+
+    function setVal(bool _val) external {
+        val = _val;
+    }
+
+    function canLiquidate(
+        address /* cTokenBorrowed */,
+        address /* cTokenCollateral */,
+        uint /* repayAmount */
+    )
+    external
+    view
+    returns(bool) {
+        return val;
+    }
+}
+


### PR DESCRIPTION
B.Protocol implements a community based liquidation mechanism for loans and transparent risk management protocol.
We plan to deploy our own markets over Rari in the coming month.

In order to support our markets a small change in the Comptroller is needed. The change can be included also in markets that do not use B.Protocol, and in this case the default behavior is unchanged.
More details on the internals of the protocol are available [here](https://docs.bprotocol.org/technical-documentation/v2).

The change was [audited](https://github.com/Fixed-Point-Solutions/published-work/blob/master/SmartContractAudits/FPS_B.AMM_Rari_Assessment_FINAL.pdf)